### PR TITLE
*: Update org name from flatcar-linux to flatcar

### DIFF
--- a/froscon-2022-08-20/README.md
+++ b/froscon-2022-08-20/README.md
@@ -19,7 +19,7 @@ cp flatcar_production_qemu_image.img.pristine flatcar_production_qemu_image.img
 
 1. Create ignition from YAML:
    ```shell
-   cat talk.yaml | docker run --rm -v $(pwd):/files -i ghcr.io/flatcar-linux/ct:latest --files-dir /files  > ignition.json
+   cat talk.yaml | docker run --rm -v $(pwd):/files -i ghcr.io/flatcar/ct:latest --files-dir /files  > ignition.json
    ```
 2. Start flatcar. Kudos to @pothos for the cool port forwarding hack.
    ```shell

--- a/kcd-berlin-2022-06-30/README.md
+++ b/kcd-berlin-2022-06-30/README.md
@@ -19,7 +19,7 @@ cp flatcar_production_qemu_image.img.pristine flatcar_production_qemu_image.img
 
 1. Create ignition from YAML:
    ```shell
-   cat talk.yaml | docker run --rm -v $(pwd):/files -i ghcr.io/flatcar-linux/ct:latest --files-dir /files  > ignition.json
+   cat talk.yaml | docker run --rm -v $(pwd):/files -i ghcr.io/flatcar/ct:latest --files-dir /files  > ignition.json
    ```
 2. Start flatcar. Kudos to @pothos for the cool port forwarding hack.
    ```shell


### PR DESCRIPTION
The PDF files still contain the old links, though.

