### PR TITLE
CAPO-sysext: script and readme for CAPO sysext demo

### DIFF
--- a/CAPO-sysext/.gitignore
+++ b/CAPO-sysext/.gitignore
@@ -1,0 +1,7 @@
+*
+!README.md
+!openstack.env.template
+!.gitignore
+!capo-demo.env
+!kured-dockerhub.yaml
+!standalone.yaml

--- a/CAPO-sysext/README.md
+++ b/CAPO-sysext/README.md
@@ -1,0 +1,152 @@
+# ClusterAPI OpenStack Flatcar Sysext demo
+
+Tools for demo-ing Flatcar deployments on ClusterAPI OpenStack using Kubernetes sysexts from the bakery.
+
+The main demo is implemented in an env file which should be sourced (`capo-demo.env`).
+The env file provides a number of helper functions to set up and run a Flatcar OpenStack deployment.
+It will set up a Kind cluster locally (one node, control plane only) to manage ClusterAPI OpenStack
+worker clusters, then spawn a worker cluster on OpenStack.
+
+## tl;dr
+
+Put `clouds.yaml` and `openstack.env` (see prerequisites) into your working directory.
+
+```
+bash -i
+source capo-demo.env
+
+get_prerequisites
+setup_kind_cluster
+generate_capo_yaml
+
+# start sshuttle before continuing (the script will pause for you).
+deploy_capo_cluster
+```
+
+Now you can use `kc_worker` to interact with the OpenStack worker cluster and `kc_mgmt` to interact with
+the local Kind management cluster.
+
+`deploy_capo_cluster` will pause and ask you to start an `sshuttle` connection to your OpenStack server.
+This is required for isolated environments that are not accessible from the internet.
+
+To clean up everything, run
+```
+cleanup
+```
+
+## Source `capo-demo.env`
+
+Before going any further, start a shell, change into your demo working directory, and `source capo-demo.env`.
+
+## Prerequisites
+
+The script requires an existing OpenStack server to deploy workload clusters to, and a corresponding
+`clouds.yaml` file with credentialy to access that server.
+That file can be acquired via the OpenStack web interface by opening "API Access" and then selecting
+"Download OpenStack RC file".
+
+The automation requires a number of prerequisite commands to be installed on the system:
+- `kubectl`
+- `yq`
+- `git`
+- `wget`
+- `sshuttle`
+Consult your distro's package management on getting these tools.
+
+The script needs to know about a number of OpenStack settings for running the demo.
+These are defined in `openstack.env`.
+Simply `cp openstack.env.template openstack.env` and fill in the information.
+
+Lastly, run
+```
+get_prerequisites
+```
+to check system prerequisites and to download `kind`, `clusterctl`, and git clone `cloud-provider-openstack`.
+
+## Set up and start a local Kind cluster
+
+Run
+```
+setup_kind_cluster
+```
+to start a local Kind cluster.
+The kubeconfig for this cluster will be stored in the current directory.
+The setup also initialises the kind cluster to be a management cluster for OpenStack CAPI.
+
+## Generate OpenStack worker cluster configuration
+
+Run
+```
+generate_capo_yaml
+```
+to generate and kustomize a CAPI cluster configuration for our OpenStack configuration.
+
+### Make local edits before provisioning the cluster
+
+You can edit `flatcar-capi-demo-openstack.yaml` with your favourite editor to make changes to the cluster before it is provisioned in the next step.
+This is useful for e.g. enabling the update feature, picking different kubernetes sysexts, etc.
+
+## Provision the OpenStack worker cluster
+
+Run
+```
+deploy_capo_cluster
+```
+to deploy the worker cluster.
+The command will ask you to start an sshuttle connection to your OpenStack server.
+This is required for isolated environments that are not accessible from the internet.
+
+Run `sshuttle -r root@<openstack-server-ip> <openstack-network-and-netmask> -l 0.0.0.0` in a separate console,
+then press return so the script continues.
+
+## Run your Demo
+
+This is what you came here for - you now have an OpenStack CAPI cluster deployed and you can demo stuff.
+
+Use `kc_worker` to `kubectl` to your worker cluster.
+
+How about investigating your node state (versions and the like)?
+```
+kc_worker get nodes -o wide
+```
+
+If you were planning to demo updates you might want to deploy kured:
+```
+kc_worker apply -f kured-dockerhub.yaml
+```
+This file is shipped with this repo and modifies the default kured YAML:
+- check interval is set to 10 seconds instead of several minutes
+- lock release is set to 0, so reboot locks are relased as soon as the node is back
+- a custom reboot sentinel command is used as kured's regular detection seems to be broken on Flatcar
+
+Also, this `cluster.yaml` systemd unit drop-in might be handy to reduce the
+sysupdate timer after boot to 1min (from its 15min default), and then every 10 seconds:
+Add this to `systemd: units:` **in both the control plane and worker node sections**:
+```
+              - name: systemd-sysupdate.timer
+                dropins:
+                  - name: bootcheck.conf
+                    contents: |
+                      [Timer]
+                      OnBootSec=1min
+                      OnUnitActiveSec=10s
+                      RandomizedDelaySec=1s
+```
+and don't forget to set `systemd-sysupdate.timer` to `enabled:true`.
+
+Check kured's status after the deployment with
+```
+kc_worker get pods --all-namespaces -o wide | grep kured | grep flatcar-capi-demo-openstack-control-plane
+```
+and then
+```
+kc_worker logs -n kube-system -f <kured-pod>
+```
+and on a separate terminal
+```
+while true; do kc_worker get nodes -o wide; echo; sleep 1; done
+```
+
+## Standalone (non-CAPI) Kubernetes sysext deployment and update
+
+A standalone Butane config is available in `standalone.yaml` to demo Kubernetes sysext provisioning in a local VM.

--- a/CAPO-sysext/README.md
+++ b/CAPO-sysext/README.md
@@ -4,8 +4,7 @@ Tools for demo-ing Flatcar deployments on ClusterAPI OpenStack using Kubernetes 
 
 The main demo is implemented in an env file which should be sourced (`capo-demo.env`).
 The env file provides a number of helper functions to set up and run a Flatcar OpenStack deployment.
-It will set up a Kind cluster locally (one node, control plane only) to manage ClusterAPI OpenStack
-worker clusters, then spawn a worker cluster on OpenStack.
+It will set-up a local [management cluster](https://cluster-api.sigs.k8s.io/user/concepts#management-cluster) using Kind to manage [workloads cluster](https://cluster-api.sigs.k8s.io/user/concepts#workload-cluster) deployments on OpenStack.
 
 ## tl;dr
 

--- a/CAPO-sysext/capo-demo.env
+++ b/CAPO-sysext/capo-demo.env
@@ -1,0 +1,214 @@
+#!/bin/bash
+
+CLUSTER_NAME="flatcar-capi-demo-openstack"
+export CLUSTER_NAME
+
+WORKER_CONTROLPLANE_NODES=1
+WORKER_NODES=2
+
+p() {
+    echo
+    echo "#####################################"
+    echo "${@}"
+    echo "-------------------------------------"
+}
+# --
+
+check_command() {
+    local cmd="$1"
+
+    if ! command -v "$cmd" &> /dev/null ; then
+        echo "'$cmd' could not be found. Please install your distro's '$cmd'."
+        return 1
+    fi
+    echo "  - '$cmd'"
+}
+# --
+
+check_file() {
+    local f="$1"
+
+    if [ ! -f "./$f" ] ; then
+        echo "prerequisite '$f' could not be found."
+        return 1
+    fi
+
+    echo "  - '$f'"
+}
+# --
+
+get_prerequisites() {
+    p "Prerequisites: Checking for required host commands."
+    check_command "kubectl" || return
+    check_command "yq" || return
+    check_command "git" || return
+    check_command "wget" || return
+    check_command "sshuttle" || return
+
+    p "Prerequisites: Checking for prerequisite files."
+    check_file "clouds.yaml" || return
+    check_file "openstack.env" || return
+
+    if [ ! -f ./clusterctl ] ; then
+        p "Prerequisites: fetching clusterctl"
+        wget https://github.com/kubernetes-sigs/cluster-api/releases/latest/download/clusterctl-linux-amd64
+        mv clusterctl-linux-amd64 clusterctl
+        chmod 755 clusterctl
+    fi
+
+    if [ ! -f ./kind ] ; then
+        p "Prerequisites: fetching kind"
+        wget https://github.com/kubernetes-sigs/kind/releases/latest/download/kind-linux-amd64
+        mv kind-linux-amd64 kind
+        chmod 755 kind
+    fi
+
+    if [ ! -d CAPO ] ; then
+        p "Prerequisites: fetching CAPO repo"
+        git clone --depth 1 \
+            https://github.com/kubernetes-sigs/cluster-api-provider-openstack \
+            CAPO
+    fi
+}
+# --
+
+setup_kind_cluster() {
+    p "Bootsstrapping cluster"
+    ./kind create cluster --kubeconfig=./kind-mgmt.kubeconfig
+    export EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION=true
+
+    p "Initialising Clustercuddle"
+    ./clusterctl init --infrastructure openstack \
+        --kubeconfig=./kind-mgmt.kubeconfig
+}
+# --
+
+kc_mgmt() {
+    kubectl --kubeconfig=./kind-mgmt.kubeconfig "${@}"
+
+}
+# --
+
+kc_worker() {
+    kubectl --kubeconfig=./${CLUSTER_NAME}.kubeconfig "${@}"
+}
+# --
+
+generate_capo_yaml() {
+    source ./CAPO/templates/env.rc ./clouds.yaml openstack
+    source ./openstack.env
+
+    p "Generating ${CLUSTER_NAME}.yaml."
+    ./clusterctl generate cluster ${CLUSTER_NAME} \
+        --kubeconfig=./kind-mgmt.kubeconfig \
+        --flavor flatcar-sysext --kubernetes-version v1.30.3 \
+        --control-plane-machine-count=${WORKER_CONTROLPLANE_NODES} \
+        --worker-machine-count=${WORKER_NODES} \
+        > ${CLUSTER_NAME}.yaml
+
+    p "Adding SSH via kustomize ssh.yaml."
+    cat > ssh.yaml <<EOF
+---
+# Allow the SSH access for demo purposes.
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  template:
+    spec:
+      securityGroups:
+        - filter:
+            name: ssh
+EOF
+cat > kustomization.yaml <<EOF
+resources:
+- ${CLUSTER_NAME}.yaml
+
+patches:
+- path: ssh.yaml
+  target:
+    kind: OpenStackMachineTemplate
+EOF
+    kc_mgmt kustomize  ./ --output ${CLUSTER_NAME}.yaml 
+}
+# --
+
+deploy_capo_cluster() {
+
+    p "PLEASE START SSHUTTLE NOW. Press return to continue."
+    read ignored
+
+    p "Creating workload cluster"
+    kc_mgmt apply -f ./${CLUSTER_NAME}.yaml
+
+    p "Waiting for cluster to be provisioned."
+    while ! kc_mgmt get cluster | grep flatcar-capi-demo-openstack | grep Provisioned ; do
+        sleep 1
+    done
+
+    # Hack alert: sometimes ended up with an empty kubeconfig from the command below, so
+    #   we add a defensive sleep.
+    sleep 2
+
+    ./clusterctl get kubeconfig ${CLUSTER_NAME} \
+            --kubeconfig=./kind-mgmt.kubeconfig \
+            --namespace default \
+            > ./${CLUSTER_NAME}.kubeconfig
+
+    p "Waiting for all nodes to come up."
+    local count=0
+    local target_count=$((WORKER_CONTROLPLANE_NODES + WORKER_NODES))
+    while [ "$count" -lt "$target_count" ] ; do
+        count="$(kc_worker --request-timeout=1s get nodes \
+                 | grep flatcar-capi-demo-openstack \
+                 | wc -l)"
+        echo "$count of $target_count nodes are up."
+    done
+
+    p "Deploying Calico so we can talk to the worker nodes"
+    kc_worker apply \
+        -f https://docs.projectcalico.org/archive/v3.23/manifests/calico.yaml
+
+    p "Creating OpenStack cloud secret"
+    CAPO/templates/create_cloud_conf.sh ./clouds.yaml openstack \
+        > ./cloud.conf
+    kc_worker create secret \
+        -n kube-system generic cloud-config --from-file=./cloud.conf
+
+    p "Deploying OpenStack controllers to worker cluster"
+    kc_worker apply \
+        -f https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/manifests/controller-manager/cloud-controller-manager-roles.yaml
+    kc_worker apply \
+        -f https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
+    kc_worker apply \
+        -f https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+
+    p "Cluster is deployed and can now be used ('kc_worker' kubectl wrapper)."
+}
+# --
+
+cleanup() {
+    kc_mgmt delete cluster ${CLUSTER_NAME}
+    ./kind delete cluster --kubeconfig=./kind-mgmt.kubeconfig
+}
+# --
+
+help() {
+    cat <<EOF
+Demo functions:
+
+ - get_prerequisites:   Check and download a number of prerequisited.
+ - setup_kind_cluster:  Create a local Kind (Kubernetes-in-docker) cluster we'll use as management cluster.
+ - generate_capo_yaml:  Generate OpenStack worker cluster configuration.
+ - deploy_capo_cluster: Apply worker cluster config to management cluster. This will create the worker cluster.
+
+You can use kubectl wrappers:
+ - kc_worker: interact with the worker cluster
+ - kc_mgmt: interact with the management cluster.
+
+ - 'cleanup' will tear down the worker cluster and remove the local management cluster.
+EOF
+}
+
+help

--- a/CAPO-sysext/kured-dockerhub.yaml
+++ b/CAPO-sysext/kured-dockerhub.yaml
@@ -1,0 +1,166 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kured
+rules:
+# Allow kured to read spec.unschedulable
+# Allow kubectl to drain/uncordon
+#
+# NB: These permissions are tightly coupled to the bundled version of kubectl; the ones below
+# match https://github.com/kubernetes/kubernetes/blob/v1.19.4/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+#
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs:     ["get", "patch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs:     ["list","delete","get"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs:     ["get"]
+- apiGroups: [""]
+  resources: ["pods/eviction"]
+  verbs:     ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kured
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kured
+subjects:
+- kind: ServiceAccount
+  name: kured
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: kured
+rules:
+# Allow kured to lock/unlock itself
+- apiGroups:     ["apps"]
+  resources:     ["daemonsets"]
+  resourceNames: ["kured"]
+  verbs:         ["update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: kube-system
+  name: kured
+subjects:
+- kind: ServiceAccount
+  namespace: kube-system
+  name: kured
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kured
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kured
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kured # Must match `--ds-name`
+  namespace: kube-system # Must match `--ds-namespace`
+spec:
+  selector:
+    matchLabels:
+      name: kured
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: kured
+    spec:
+      serviceAccountName: kured
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      hostPID: true # Facilitate entering the host mount namespace via init
+      restartPolicy: Always
+      volumes:
+        - name: sentinel
+          hostPath:
+            path: /var/run
+            type: Directory
+      containers:
+        - name: kured
+          # If you find yourself here wondering why there is no
+          # :latest tag on Docker Hub,see the FAQ in the README
+          image: ghcr.io/kubereboot/kured:1.16.0
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true # Give permission to nsenter /proc/1/ns/mnt
+            readOnlyRootFilesystem: true
+          ports:
+            - containerPort: 8080
+              name: metrics
+          env:
+            # Pass in the name of the node on which this pod is scheduled
+            # for use with drain/uncordon operations and lock acquisition
+            - name: KURED_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /sentinel
+              name: sentinel
+              readOnly: true
+          command:
+            - /usr/bin/kured
+            - --period=10s
+            - --reboot-sentinel-command=/usr/bin/test -f /run/reboot-required
+            - --lock-release-delay=0
+            - --reboot-delay=0
+#            - --force-reboot=false
+#            - --drain-grace-period=-1
+#            - --skip-wait-for-delete-timeout=0
+#            - --drain-delay=0
+#            - --drain-timeout=0
+#            - --drain-pod-selector=""
+#            - --ds-namespace=kube-system
+#            - --ds-name=kured
+#            - --lock-annotation=weave.works/kured-node-lock
+#            - --lock-ttl=0
+#            - --prometheus-url=http://prometheus.monitoring.svc.cluster.local
+#            - --alert-filter-regexp=^RebootRequired$
+#            - --alert-filter-match-only=false
+#            - --alert-firing-only=false
+#            - --prefer-no-schedule-taint=""
+#            - --reboot-sentinel-command=""
+#            - --reboot-method=command
+#            - --reboot-signal=39
+#            - --slack-hook-url=https://hooks.slack.com/...
+#            - --slack-username=prod
+#            - --slack-channel=alerting
+#            - --notify-url="" # See also shoutrrr url format
+#            - --message-template-drain=Draining node %s
+#            - --message-template-reboot=Rebooting node %s
+#            - --message-template-uncordon=Node %s rebooted & uncordoned successfully!
+#            - --blocking-pod-selector=runtime=long,cost=expensive
+#            - --blocking-pod-selector=name=temperamental
+#            - --blocking-pod-selector=...
+#            - --reboot-days=sun,mon,tue,wed,thu,fri,sat
+#            - --reboot-delay=90s
+#            - --start-time=0:00
+#            - --end-time=23:59:59
+#            - --time-zone=UTC
+#            - --annotate-nodes=false
+#            - --log-format=text
+#            - --metrics-host=""
+#            - --metrics-port=8080
+#            - --concurrency=1

--- a/CAPO-sysext/openstack.env.template
+++ b/CAPO-sysext/openstack.env.template
@@ -1,0 +1,13 @@
+# Template env for openstack demo. Rename to openstack.env and fill in the below.
+export OPENSTACK_FAILURE_DOMAIN=
+export OPENSTACK_EXTERNAL_NETWORK_ID=
+export OPENSTACK_CLOUD=
+export FLATCAR_IMAGE_NAME=
+
+# Required for SSHing into machine
+export OPENSTACK_SSH_KEY_NAME=t-lo
+
+# Can be left as is or changed if needed
+export OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR=m1.medium
+export OPENSTACK_DNS_NAMESERVERS=8.8.8.8
+export OPENSTACK_NODE_MACHINE_FLAVOR=m1.medium

--- a/CAPO-sysext/standalone.yaml
+++ b/CAPO-sysext/standalone.yaml
@@ -1,0 +1,43 @@
+variant: flatcar
+version: 1.0.0
+
+storage:
+  links:
+    - target: /opt/extensions/kubernetes/kubernetes-v1.30.1-x86-64.raw
+      path: /etc/extensions/kubernetes.raw
+      hard: false
+  files:
+    - path: /opt/extensions/kubernetes/kubernetes-v1.30.1-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-v1.30.1-x86-64.raw
+    - path: /etc/sysupdate.kubernetes.d/kubernetes-v1.30.conf
+      mode: 0644
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-v1.30.conf
+    - path: /etc/flatcar/update.conf
+      overwrite: true
+      contents:
+        inline: |
+          REBOOT_STRATEGY=off
+      mode: 0420
+    - path: /etc/sysupdate.d/noop.conf
+      mode: 0644
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: false 
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: kubernetes.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kubernetes.raw > /tmp/kubernetes"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C kubernetes update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kubernetes.raw > /tmp/kubernetes-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/kubernetes /tmp/kubernetes-new; then touch /run/reboot-required; fi"
+    - name: update-engine.service
+      mask: true


### PR DESCRIPTION
ClusterAPI OpenStack sysext demo instructions and automation (script).

See included README.md for more information.

## How to use

Follow instructions in README.md. Requires access to an OpenStack server.

## Testing done

Followed the instructions in README.md and deployed a number of clusters.