### PR TITLE
docs: add community docs, update README badges and references

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+The Flatcar project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+
+For details on how we uphold community standards across all Flatcar repositories, please see the [main Flatcar Code of Conduct](https://github.com/flatcar/Flatcar/blob/main/CODE_OF_CONDUCT.md).
+
+## Reporting
+
+If you experience or witness unacceptable behavior, please report it following the process outlined in the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Whether you're fixing a bug, adding a feature, or improving docs — we apprecia
 
 For more detailed guidelines (finding issues, community meetings, PR lifecycle, commit message format, and more), check out the [main Flatcar CONTRIBUTING guide](https://github.com/flatcar/Flatcar/blob/main/CONTRIBUTING.md).
 
+If you want to file an issue for any Flatcar repository, please use the [central Flatcar issue tracker](https://github.com/flatcar/Flatcar/issues).
+
 ---
 
 ## Repository Specific Guidelines

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,11 @@
+# Governance
+
+For details on the Flatcar project governance model, decision-making process, and roles, please see the [main Flatcar Governance document](https://github.com/flatcar/Flatcar/blob/main/governance.md).
+
+---
+
+## Repository-Specific Governance
+
+Any governance details specific to this repository will be listed here.
+
+<!-- Add repo-specific governance notes below this line -->

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,11 @@
+# Maintainers
+
+For the current list of maintainers and their responsibilities, please see the [main Flatcar MAINTAINERS file](https://github.com/flatcar/Flatcar/blob/main/MAINTAINERS.md).
+
+---
+
+## Repository-Specific Maintainers
+
+Any maintainers specific to this repository will be listed here.
+
+<!-- Add repo-specific maintainers below this line -->

--- a/README.md
+++ b/README.md
@@ -1,13 +1,27 @@
 <div style="text-align: center">
 
 [![Flatcar OS](https://img.shields.io/badge/Flatcar-Website-blue?logo=data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyNi4wLjMsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4wIiBpZD0ia2F0bWFuXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgODAwIDYwMCIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgODAwIDYwMDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPg0KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4NCgkuc3Qwe2ZpbGw6IzA5QkFDODt9DQo8L3N0eWxlPg0KPHBhdGggY2xhc3M9InN0MCIgZD0iTTQ0MCwxODIuOGgtMTUuOXYxNS45SDQ0MFYxODIuOHoiLz4NCjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik00MDAuNSwzMTcuOWgtMzEuOXYxNS45aDMxLjlWMzE3Ljl6Ii8+DQo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNNTQzLjgsMzE3LjlINTEydjE1LjloMzEuOVYzMTcuOXoiLz4NCjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik02NTUuMiw0MjAuOXYtOTUuNGgtMTUuOXY5NS40aC0xNS45VjI2MmgtMzEuOVYxMzQuOEgyMDkuNFYyNjJoLTMxLjl2MTU5aC0xNS45di05NS40aC0xNnY5NS40aC0xNS45djMxLjINCgloMzEuOXYxNS44aDQ3Ljh2LTE1LjhoMTUuOXYxNS44SDI3M3YtMTUuOGgyNTQuOHYxNS44aDQ3Ljh2LTE1LjhoMTUuOXYxNS44aDQ3Ljh2LTE1LjhoMzEuOXYtMzEuMkg2NTUuMnogTTQ4Ny44LDE1MWg3OS42djMxLjgNCgloLTIzLjZ2NjMuNkg1MTJ2LTYzLjZoLTI0LjJMNDg3LjgsMTUxTDQ4Ny44LDE1MXogTTIzMywyMTQuNlYxNTFoNjMuN3YyMy41aC0zMS45djE1LjhoMzEuOXYyNC4yaC0zMS45djMxLjhIMjMzVjIxNC42eiBNMzA1LDMxNy45DQoJdjE1LjhoLTQ3Ljh2MzEuOEgzMDV2NDcuN2gtOTUuNVYyODYuMUgzMDVMMzA1LDMxNy45eiBNMzEyLjYsMjQ2LjRWMTUxaDMxLjl2NjMuNmgzMS45djMxLjhMMzEyLjYsMjQ2LjRMMzEyLjYsMjQ2LjRMMzEyLjYsMjQ2LjR6DQoJIE00NDguMywzMTcuOXY5NS40aC00Ny44di00Ny43aC0zMS45djQ3LjdoLTQ3LjhWMzAyaDE1Ljl2LTE1LjhoOTUuNVYzMDJoMTUuOUw0NDguMywzMTcuOXogTTQ0MCwyNDYuNHYtMzEuOGgtMTUuOXYzMS44aC0zMS45DQoJdi03OS41aDE1Ljl2LTE1LjhoNDcuOHYxNS44aDE1Ljl2NzkuNUg0NDB6IE01OTEuNiwzMTcuOXY0Ny43aC0xNS45djE1LjhoMTUuOXYzMS44aC00Ny44di0zMS43SDUyOHYtMTUuOGgtMTUuOXY0Ny43aC00Ny44VjI4Ni4xDQoJaDEyNy4zVjMxNy45eiIvPg0KPC9zdmc+DQo=)](https://www.flatcar.org/)
+[![Discord](https://img.shields.io/badge/Discord-Chat%20with%20us!-5865F2?logo=discord)](https://discord.gg/PMYjFUsJyq)
 [![Matrix](https://img.shields.io/badge/Matrix-Chat%20with%20us!-green?logo=matrix)](https://app.element.io/#/room/#flatcar:matrix.org)
 [![Twitter Follow](https://img.shields.io/twitter/follow/flatcar?style=social)](https://x.com/flatcar)
 [![Mastodon Follow](https://img.shields.io/badge/Mastodon-Follow-6364FF?logo=mastodon)](https://hachyderm.io/@flatcar)
 [![Bluesky](https://img.shields.io/badge/Bluesky-Follow-0285FF?logo=bluesky)](https://bsky.app/profile/flatcar.org)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10926/badge)](https://www.bestpractices.dev/projects/10926)
 [![Slack](https://img.shields.io/badge/Slack-Chat%20with%20us!-4A154B?logo=slack)](https://kubernetes.slack.com/archives/C03GQ8B5XNJ)
 
+
+> **Note:** To file an issue for any Flatcar repository, please use the [central Flatcar issue tracker](https://github.com/flatcar/Flatcar/issues).
 </div>
 
 # flatcar-demos
 A collection of demos shown at conferences, meetups, and the like.
+
+---
+
+## Community & Project Documentation
+
+- [Contributing Guidelines](CONTRIBUTING.md) — How to contribute, find issues, and submit pull requests
+- [Code of Conduct](CODE_OF_CONDUCT.md) — Standards for respectful and inclusive community participation
+- [Security Policy](SECURITY.md) — How to report vulnerabilities and security-related information
+- [Maintainers](MAINTAINERS.md) — Current project maintainers and their responsibilities
+- [Governance](GOVERNANCE.md) — Project governance model, decision-making process, and roles

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+The Flatcar project takes security seriously. We appreciate your efforts to responsibly disclose your findings.
+
+For our full security policy, supported versions, and how to report a vulnerability, please see the [main Flatcar Security Policy](https://github.com/flatcar/Flatcar/blob/main/SECURITY.md).
+
+**Please do not open public issues for security vulnerabilities.**
+
+---
+
+## Repository-Specific Security Notes
+
+Any security considerations specific to this repository will be listed here.
+
+<!-- Add repo-specific security notes below this line -->


### PR DESCRIPTION
## Summary

This PR adds standardized community documentation files and updates the README:

### New files
- **`SECURITY.md`** — Links to the [main Flatcar Security Policy](https://github.com/flatcar/Flatcar/blob/main/SECURITY.md) with a section for repo-specific security notes
- **`MAINTAINERS.md`** — Links to the [main Flatcar MAINTAINERS file](https://github.com/flatcar/Flatcar/blob/main/MAINTAINERS.md) with a section for repo-specific maintainers
- **`GOVERNANCE.md`** — Links to the [main Flatcar Governance document](https://github.com/flatcar/Flatcar/blob/main/governance.md) with a section for repo-specific governance
- **`CODE_OF_CONDUCT.md`** — Links to the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md) and the [main Flatcar Code of Conduct](https://github.com/flatcar/Flatcar/blob/main/CODE_OF_CONDUCT.md)

### Updated files
- **`CONTRIBUTING.md`** — Added a note directing users to the [central Flatcar issue tracker](https://github.com/flatcar/Flatcar/issues)

### README.md updates
- Added **Discord** badge ([Flatcar Discord server](https://discord.gg/PMYjFUsJyq))
- Added **OpenSSF Best Practices** badge ([project 10926](https://www.bestpractices.dev/projects/10926))
- Added a note pointing to the [central Flatcar issue tracker](https://github.com/flatcar/Flatcar/issues)
- Appended a **Community & Project Documentation** reference section linking to all community docs

This change is part of a batch update across all Flatcar repositories to ensure consistent community documentation.

Ref: https://github.com/flatcar/Flatcar/issues/1865
